### PR TITLE
Added support for null values in the database.

### DIFF
--- a/src/Type/AbstractPhpEnumType.php
+++ b/src/Type/AbstractPhpEnumType.php
@@ -44,8 +44,17 @@ abstract class AbstractPhpEnumType extends Type
         return 'VARCHAR(256) COMMENT "php_enum"';
     }
 
+    /**
+     * @param string $value
+     * @param AbstractPlatform $platform
+     * @return mixed
+     */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
+        if (is_null($value)) {
+            return null;
+        }
+
         $isValid = call_user_func([$this->enumType, 'isValid'], $value);
         if (! $isValid) {
             throw new InvalidArgumentException(sprintf(

--- a/tests/Type/AbstractPhpEnumTypeTest.php
+++ b/tests/Type/AbstractPhpEnumTypeTest.php
@@ -75,6 +75,12 @@ class AbstractPhpEnumTypeTest extends TestCase
         $this->assertEquals(Action::DELETE, $value->getValue());
     }
 
+    public function testConvertToPHPValueWithNull()
+    {
+        $value = $this->type->convertToPHPValue(null, $this->platform);
+        $this->assertSame(null, $value);
+    }
+
     /**
      * @expectedException \Acelaya\Doctrine\Exception\InvalidArgumentException
      */


### PR DESCRIPTION
Sometimes database results may bring back NULL results, either because the property is nullable or as a result of an empty left join.
In this case entities will be hydrated with null, rather than failing due to an invalid enum type.

This will resolve #1 
