### PR TITLE
Removed column comment from type SQL declaration.

### DIFF
--- a/src/Type/AbstractPhpEnumType.php
+++ b/src/Type/AbstractPhpEnumType.php
@@ -41,7 +41,7 @@ abstract class AbstractPhpEnumType extends Type
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        return 'VARCHAR(256) COMMENT "php_enum"';
+        return $platform->getVarcharTypeDeclarationSQL([]);
     }
 
     /**

--- a/tests/Type/AbstractPhpEnumTypeTest.php
+++ b/tests/Type/AbstractPhpEnumTypeTest.php
@@ -42,8 +42,12 @@ class AbstractPhpEnumTypeTest extends TestCase
 
     public function testGetSQLDeclaration()
     {
+        $this->platform
+            ->method('getVarcharTypeDeclarationSQL')
+            ->will($this->returnValue('declaration'));
+
         $this->assertEquals(
-            'VARCHAR(256) COMMENT "php_enum"',
+            'declaration',
             $this->type->getSQLDeclaration([], $this->platform)
         );
     }


### PR DESCRIPTION
Some platforms supported by doctrine don't support comments (e.g sqlite, which I'm trying to use for integration tests). Looking into the primary doctrine column definitions it doesn't seem like doctrine uses comments anywhere.

Seeing as the comment doesn't seem to have any programmtic use I've removed it.
