### PR TITLE
Allow null value

### DIFF
--- a/src/Type/PhpEnumType.php
+++ b/src/Type/PhpEnumType.php
@@ -68,7 +68,7 @@ class PhpEnumType extends Type
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        return (string) $value;
+        return ($value === null) ? null : (string) $value;
     }
 
     /**


### PR DESCRIPTION
Casting the value to a string does not allow an enum value to be null.