### PR TITLE
Fix docblock

### DIFF
--- a/src/Type/PhpEnumType.php
+++ b/src/Type/PhpEnumType.php
@@ -72,8 +72,8 @@ class PhpEnumType extends Type
     }
 
     /**
-     * @param $typeNameOrEnumClass
-     * @param null $enumClass
+     * @param string $typeNameOrEnumClass
+     * @param string|null $enumClass
      * @throws InvalidArgumentException
      * @throws DBALException
      */


### PR DESCRIPTION
PHPStan alerts second parameter should always be null