### PR TITLE
Require SQL comment hint

### DIFF
--- a/src/Type/PhpEnumType.php
+++ b/src/Type/PhpEnumType.php
@@ -110,4 +110,13 @@ class PhpEnumType extends Type
             static::registerEnumType($typeName, $enumClass);
         }
     }
+
+    /**
+     * @param AbstractPlatform $platform
+     * @return boolean
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/tests/Type/PhpEnumTypeTest.php
+++ b/tests/Type/PhpEnumTypeTest.php
@@ -194,4 +194,15 @@ class PhpEnumTypeTest extends TestCase
             $type->getSQLDeclaration([], $this->platform->reveal())
         );
     }
+
+    /**
+     * @test
+     */
+    public function SQLCommentHintIsAlwaysRequired()
+    {
+        PhpEnumType::registerEnumType(Gender::class);
+        $type = Type::getType(Gender::class);
+
+        $this->assertTrue($type->requiresSQLCommentHint($this->platform->reveal()));
+    }
 }


### PR DESCRIPTION
Doctrine can't detect field type with no comment hint when get schema from DB.
For example, Doctrine creates migration with changing field type even if field type is already correct.